### PR TITLE
Reorder media queries to apply priority

### DIFF
--- a/style.css
+++ b/style.css
@@ -54,14 +54,14 @@ body{
     background-size: auto 100%;
 }
 
-@media screen and (min-width: 1400px) {
-    body{
-        background-image: url(images/backgrounds/large.jpg);
-    }
-}
 @media screen and (min-width: 701px) {
     body{
         background-image: url(images/backgrounds/medium.jpg);
+    }
+}
+@media screen and (min-width: 1400px) {
+    body{
+        background-image: url(images/backgrounds/large.jpg);
     }
 }
 @media screen and (max-width: 700px) {


### PR DESCRIPTION
Sur les écrans > 701px de large, les deux media-queries sont vraies et c'est la dernière dans le code qui est prise en compte (priorité CSS). Du coup, la `large.jpg` n'est jamais utilisé.
Cette PR corrige ce souci :smile:

Vive le désert de l'Est ![Amour sablé](https://cdn.discordapp.com/emojis/906293224539324536.png?size=32)